### PR TITLE
Fix fleetroc ID in fleetroc_snappy.yaml

### DIFF
--- a/sut/fleetroc_snappy.yaml
+++ b/sut/fleetroc_snappy.yaml
@@ -1,5 +1,5 @@
 device_ip: 10.245.130.10
-node_id: am44yr
+node_id: gwmhd6
 node_name: fleetroc
 maas_user: testflinger_a
 agent_name: fleetroc


### PR DESCRIPTION
Fleetroc's MAAS ID has changed, and fleetroc_snappy.yaml wasn't updated to match. This PR fixes this issue.