### PR TITLE
Correct a typo in timeout.

### DIFF
--- a/code/maas_node_to_tf_configs.py
+++ b/code/maas_node_to_tf_configs.py
@@ -71,7 +71,7 @@ def write_testflinger_config(output_dir, hostname, machine):
     testflinger_config["agent_id"] = hostname
     testflinger_config["server_address"] = "https://testflinger.canonical.com:443"
     testflinger_config["global_timeout"] = 172800
-    testflinger_config["output_timeouit"] = 43200
+    testflinger_config["output_timeout"] = 43200
     testflinger_config[
         "execution_basedir"
     ] = f"/data/testflinger-agent/tests/{hostname}/run"

--- a/sut/aitken.conf
+++ b/sut/aitken.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/aitken/logs
 results_basedir: /data/testflinger-agent/tests/aitken/results
 logging_level: INFO
 job_queues:
-- aitken
 - anything
+- aitken
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/aitken_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/aitken_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/aitken_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/aitken_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/barbos.conf
+++ b/sut/barbos.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/barbos_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/barbos_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/barbos_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/beldam.conf
+++ b/sut/beldam.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/beldam/logs
 results_basedir: /data/testflinger-agent/tests/beldam/results
 logging_level: INFO
 job_queues:
-- beldam
 - anything
+- beldam
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/beldam_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/beldam_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/beldam_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/beldam_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/birdo.conf
+++ b/sut/birdo.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/birdo_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/birdo_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/birdo_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/blubi.conf
+++ b/sut/blubi.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/blubi_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/blubi_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/blubi_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/bomberto.conf
+++ b/sut/bomberto.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/bomberto_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/bomberto_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/bomberto_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/boshi.conf
+++ b/sut/boshi.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/boshi_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/boshi_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/boshi_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/buzzar.conf
+++ b/sut/buzzar.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/buzzar_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/buzzar_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/buzzar_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/cappy.conf
+++ b/sut/cappy.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/cappy/logs
 results_basedir: /data/testflinger-agent/tests/cappy/results
 logging_level: INFO
 job_queues:
-- cappy
 - anything
+- cappy
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/cappy_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/cappy_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/cappy_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/cappy_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/cloaker.conf
+++ b/sut/cloaker.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/cloaker/logs
 results_basedir: /data/testflinger-agent/tests/cloaker/results
 logging_level: INFO
 job_queues:
-- cloaker
 - anything
+- cloaker
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/cloaker_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/cloaker_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/cloaker_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/cloaker_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/coinfish.conf
+++ b/sut/coinfish.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/coinfish_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/coinfish_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/coinfish_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/cractus.conf
+++ b/sut/cractus.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/cractus_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/cractus_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/cractus_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/danet.conf
+++ b/sut/danet.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/danet/logs
 results_basedir: /data/testflinger-agent/tests/danet/results
 logging_level: INFO
 job_queues:
-- danet
 - anything
+- danet
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/danet_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/danet_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/danet_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/danet_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/donkeykong.conf
+++ b/sut/donkeykong.conf
@@ -19,7 +19,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/donkeykong_snappy.yaml testflinger.json ||
   /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/donkeykong_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/doubletusk.conf
+++ b/sut/doubletusk.conf
@@ -19,7 +19,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/doubletusk_snappy.yaml testflinger.json ||
   /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/doubletusk_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/drapion.conf
+++ b/sut/drapion.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/drapion/logs
 results_basedir: /data/testflinger-agent/tests/drapion/results
 logging_level: INFO
 job_queues:
-- drapion
 - anything
+- drapion
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/drapion_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/drapion_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/drapion_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/drapion_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/drilbur.conf
+++ b/sut/drilbur.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/drilbur_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/drilbur_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/drilbur_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/eely.conf
+++ b/sut/eely.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/eely/logs
 results_basedir: /data/testflinger-agent/tests/eely/results
 logging_level: INFO
 job_queues:
-- eely
 - anything
+- eely
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/eely_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/eely_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/eely_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/eely_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/elden.conf
+++ b/sut/elden.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/elden_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/elden_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/elden_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/elroy.conf
+++ b/sut/elroy.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/elroy/logs
 results_basedir: /data/testflinger-agent/tests/elroy/results
 logging_level: INFO
 job_queues:
-- anything
 - elroy
+- anything
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/elroy_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/elroy_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/elroy_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/elroy_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/fava.conf
+++ b/sut/fava.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/fava_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/fava_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/fava_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/fesenkov.conf
+++ b/sut/fesenkov.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/fesenkov_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/fesenkov_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/fesenkov_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/ficet.conf
+++ b/sut/ficet.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/ficet_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/ficet_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/ficet_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/flavio.conf
+++ b/sut/flavio.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/flavio/logs
 results_basedir: /data/testflinger-agent/tests/flavio/results
 logging_level: INFO
 job_queues:
-- flavio
 - anything
+- flavio
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/flavio_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/flavio_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/flavio_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/flavio_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/fleep.conf
+++ b/sut/fleep.conf
@@ -1,4 +1,4 @@
-  agent_id: fleep
+agent_id: fleep
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
 output_timeout: 43200
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/fleep_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/fleep_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/fleep_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/fleetroc.conf
+++ b/sut/fleetroc.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/fleetroc/logs
 results_basedir: /data/testflinger-agent/tests/fleetroc/results
 logging_level: INFO
 job_queues:
-- fleetroc
 - anything
+- fleetroc
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/fleetroc_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/fleetroc_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/fleetroc_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/fleetroc_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/garamond.conf
+++ b/sut/garamond.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/garamond/logs
 results_basedir: /data/testflinger-agent/tests/garamond/results
 logging_level: INFO
 job_queues:
-- garamond
 - anything
+- garamond
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/garamond_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/garamond_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/garamond_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/garamond_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/gloomer.conf
+++ b/sut/gloomer.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/gloomer_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/gloomer_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/gloomer_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/gurley.conf
+++ b/sut/gurley.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/gurley/logs
 results_basedir: /data/testflinger-agent/tests/gurley/results
 logging_level: INFO
 job_queues:
-- gurley
 - anything
+- gurley
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/gurley_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/gurley_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/gurley_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/gurley_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/hardhat.conf
+++ b/sut/hardhat.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/hardhat/logs
 results_basedir: /data/testflinger-agent/tests/hardhat/results
 logging_level: INFO
 job_queues:
-- hardhat
 - anything
+- hardhat
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hardhat_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/hardhat_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/hardhat_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hardhat_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/hildy.conf
+++ b/sut/hildy.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/hildy/logs
 results_basedir: /data/testflinger-agent/tests/hildy/results
 logging_level: INFO
 job_queues:
-- hildy
 - anything
+- hildy
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hildy_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/hildy_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/hildy_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hildy_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/hinopio.conf
+++ b/sut/hinopio.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/hinopio_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/hinopio_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hinopio_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/hoggus.conf
+++ b/sut/hoggus.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/hoggus/logs
 results_basedir: /data/testflinger-agent/tests/hoggus/results
 logging_level: INFO
 job_queues:
-- hoggus
 - anything
+- hoggus
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hoggus_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/hoggus_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/hoggus_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hoggus_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/hogplum.conf
+++ b/sut/hogplum.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/hogplum_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/hogplum_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/hogplum_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/jamano.conf
+++ b/sut/jamano.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/jamano/logs
 results_basedir: /data/testflinger-agent/tests/jamano/results
 logging_level: INFO
 job_queues:
-- jamano
 - anything
+- jamano
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/jamano_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/jamano_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/jamano_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/jamano_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/jamiet.conf
+++ b/sut/jamiet.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/jamiet_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/jamiet_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/jamiet_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/joliet.conf
+++ b/sut/joliet.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/joliet_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/joliet_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/joliet_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/juppi.conf
+++ b/sut/juppi.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/juppi/logs
 results_basedir: /data/testflinger-agent/tests/juppi/results
 logging_level: INFO
 job_queues:
-- juppi
 - anything
+- juppi
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/juppi_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/juppi_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/juppi_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/juppi_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/keylime.conf
+++ b/sut/keylime.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/keylime_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/keylime_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/keylime_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/kies.conf
+++ b/sut/kies.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/kies_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kies_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kies_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/kongfu.conf
+++ b/sut/kongfu.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/kongfu_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kongfu_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kongfu_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/krunch.conf
+++ b/sut/krunch.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/krunch_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/krunch_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/krunch_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/kuribo.conf
+++ b/sut/kuribo.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/kuribo/logs
 results_basedir: /data/testflinger-agent/tests/kuribo/results
 logging_level: INFO
 job_queues:
-- kuribo
 - anything
+- kuribo
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kuribo_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/kuribo_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kuribo_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kuribo_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/kvm-large-1.conf
+++ b/sut/kvm-large-1.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-large-1
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-large-1/run
 logging_basedir: /data/testflinger-agent/tests/kvm-large-1/logs
 results_basedir: /data/testflinger-agent/tests/kvm-large-1/results
 logging_level: INFO
 job_queues:
 - kvm-large
+- anything
 - kvm-large-1
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-large-1_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-large-2.conf
+++ b/sut/kvm-large-2.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-large-2
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-large-2/run
 logging_basedir: /data/testflinger-agent/tests/kvm-large-2/logs
 results_basedir: /data/testflinger-agent/tests/kvm-large-2/results
 logging_level: INFO
 job_queues:
-- kvm-large-2
 - kvm-large
+- anything
+- kvm-large-2
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-large-2_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-large-2_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-large-3.conf
+++ b/sut/kvm-large-3.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-large-3
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-large-3/run
 logging_basedir: /data/testflinger-agent/tests/kvm-large-3/logs
 results_basedir: /data/testflinger-agent/tests/kvm-large-3/results
 logging_level: INFO
 job_queues:
 - kvm-large
+- anything
 - kvm-large-3
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-large-3_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-large-4.conf
+++ b/sut/kvm-large-4.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-large-4
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-large-4/run
 logging_basedir: /data/testflinger-agent/tests/kvm-large-4/logs
 results_basedir: /data/testflinger-agent/tests/kvm-large-4/results
 logging_level: INFO
 job_queues:
 - kvm-large
+- anything
 - kvm-large-4
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-large-4_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-large-5.conf
+++ b/sut/kvm-large-5.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-large-5
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-large-5/run
 logging_basedir: /data/testflinger-agent/tests/kvm-large-5/logs
 results_basedir: /data/testflinger-agent/tests/kvm-large-5/results
 logging_level: INFO
 job_queues:
 - kvm-large
+- anything
 - kvm-large-5
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-large-5_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-large-6.conf
+++ b/sut/kvm-large-6.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-large-6
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-large-6/run
 logging_basedir: /data/testflinger-agent/tests/kvm-large-6/logs
 results_basedir: /data/testflinger-agent/tests/kvm-large-6/results
 logging_level: INFO
 job_queues:
 - kvm-large
+- anything
 - kvm-large-6
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-large-6_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-medium-1.conf
+++ b/sut/kvm-medium-1.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-medium-1
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-medium-1/run
 logging_basedir: /data/testflinger-agent/tests/kvm-medium-1/logs
 results_basedir: /data/testflinger-agent/tests/kvm-medium-1/results
 logging_level: INFO
 job_queues:
 - kvm-medium-1
+- anything
 - kvm-medium
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-medium-1_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-medium-2.conf
+++ b/sut/kvm-medium-2.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-medium-2
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-medium-2/run
 logging_basedir: /data/testflinger-agent/tests/kvm-medium-2/logs
 results_basedir: /data/testflinger-agent/tests/kvm-medium-2/results
 logging_level: INFO
 job_queues:
-- kvm-medium
+- anything
 - kvm-medium-2
+- kvm-medium
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-medium-2_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-medium-2_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-medium-3.conf
+++ b/sut/kvm-medium-3.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-medium-3
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-medium-3/run
 logging_basedir: /data/testflinger-agent/tests/kvm-medium-3/logs
 results_basedir: /data/testflinger-agent/tests/kvm-medium-3/results
 logging_level: INFO
 job_queues:
-- kvm-medium
+- anything
 - kvm-medium-3
+- kvm-medium
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-medium-3_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-medium-3_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-medium-4.conf
+++ b/sut/kvm-medium-4.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-medium-4
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-medium-4/run
 logging_basedir: /data/testflinger-agent/tests/kvm-medium-4/logs
 results_basedir: /data/testflinger-agent/tests/kvm-medium-4/results
 logging_level: INFO
 job_queues:
-- kvm-medium
+- anything
 - kvm-medium-4
+- kvm-medium
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-medium-4_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-medium-4_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-medium-5.conf
+++ b/sut/kvm-medium-5.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-medium-5
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-medium-5/run
 logging_basedir: /data/testflinger-agent/tests/kvm-medium-5/logs
 results_basedir: /data/testflinger-agent/tests/kvm-medium-5/results
 logging_level: INFO
 job_queues:
-- kvm-medium
 - kvm-medium-5
+- anything
+- kvm-medium
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-medium-5_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-medium-5_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-medium-6.conf
+++ b/sut/kvm-medium-6.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-medium-6
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-medium-6/run
 logging_basedir: /data/testflinger-agent/tests/kvm-medium-6/logs
 results_basedir: /data/testflinger-agent/tests/kvm-medium-6/results
 logging_level: INFO
 job_queues:
-- kvm-medium
+- anything
 - kvm-medium-6
+- kvm-medium
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-medium-6_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-medium-6_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-1.conf
+++ b/sut/kvm-small-1.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-1
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-1/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-1/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-1/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-1
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-1_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-10.conf
+++ b/sut/kvm-small-10.conf
@@ -1,7 +1,6 @@
 agent_id: kvm-small-10
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-10/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-10/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-10/results
@@ -9,6 +8,7 @@ logging_level: INFO
 job_queues:
 - kvm-small
 - kvm-small-10
+- anything
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-small-10_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-10_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-11.conf
+++ b/sut/kvm-small-11.conf
@@ -1,7 +1,6 @@
 agent_id: kvm-small-11
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-11/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-11/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-11/results
@@ -9,6 +8,7 @@ logging_level: INFO
 job_queues:
 - kvm-small
 - kvm-small-11
+- anything
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-small-11_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-11_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-12.conf
+++ b/sut/kvm-small-12.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-12
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-12/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-12/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-12/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-12
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-12_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-13.conf
+++ b/sut/kvm-small-13.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-13
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-13/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-13/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-13/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-13
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-13_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-14.conf
+++ b/sut/kvm-small-14.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-14
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-14/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-14/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-14/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-14
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-14_snappy.yaml testflinger.json
   || /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-2.conf
+++ b/sut/kvm-small-2.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-2
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-2/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-2/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-2/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-2
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-2_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-3.conf
+++ b/sut/kvm-small-3.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-small-3
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-3/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-3/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-3/results
 logging_level: INFO
 job_queues:
-- kvm-small
 - kvm-small-3
+- kvm-small
+- anything
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-small-3_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-3_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-4.conf
+++ b/sut/kvm-small-4.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-4
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-4/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-4/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-4/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-4
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-4_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-5.conf
+++ b/sut/kvm-small-5.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-5
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-5/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-5/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-5/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-5
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-5_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-6.conf
+++ b/sut/kvm-small-6.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-small-6
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-6/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-6/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-6/results
 logging_level: INFO
 job_queues:
-- kvm-small-6
 - kvm-small
+- anything
+- kvm-small-6
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-small-6_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-6_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-7.conf
+++ b/sut/kvm-small-7.conf
@@ -1,14 +1,14 @@
 agent_id: kvm-small-7
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-7/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-7/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-7/results
 logging_level: INFO
 job_queues:
-- kvm-small-7
 - kvm-small
+- anything
+- kvm-small-7
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/kvm-small-7_snappy.yaml testflinger.json
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-7_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-8.conf
+++ b/sut/kvm-small-8.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-8
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-8/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-8/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-8/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-8
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-8_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/kvm-small-9.conf
+++ b/sut/kvm-small-9.conf
@@ -1,13 +1,13 @@
 agent_id: kvm-small-9
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
-output_timeouit: 43200
 execution_basedir: /data/testflinger-agent/tests/kvm-small-9/run
 logging_basedir: /data/testflinger-agent/tests/kvm-small-9/logs
 results_basedir: /data/testflinger-agent/tests/kvm-small-9/results
 logging_level: INFO
 job_queues:
 - kvm-small
+- anything
 - kvm-small-9
 setup_command: echo Setup
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
@@ -21,3 +21,4 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/kvm-small-9_snappy.yaml testflinger.json ||
   /bin/true
+output_timeout: 43200

--- a/sut/lalande.conf
+++ b/sut/lalande.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/lalande_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/lalande_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/lalande_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/luma.conf
+++ b/sut/luma.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/luma_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/luma_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/luma_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/makrutlime.conf
+++ b/sut/makrutlime.conf
@@ -19,7 +19,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/makrutlime_snappy.yaml testflinger.json ||
   /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/makrutlime_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/manta.conf
+++ b/sut/manta.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/manta/logs
 results_basedir: /data/testflinger-agent/tests/manta/results
 logging_level: INFO
 job_queues:
-- manta
 - anything
+- manta
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/manta_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/manta_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/manta_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/manta_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/mayapple.conf
+++ b/sut/mayapple.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/mayapple_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/mayapple_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/mayapple_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/mokura.conf
+++ b/sut/mokura.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/mokura_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/mokura_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/mokura_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/mouchez.conf
+++ b/sut/mouchez.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/mouchez/logs
 results_basedir: /data/testflinger-agent/tests/mouchez/results
 logging_level: INFO
 job_queues:
-- mouchez
 - anything
+- mouchez
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/mouchez_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/mouchez_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/mouchez_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/mouchez_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/mouser.conf
+++ b/sut/mouser.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/mouser_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/mouser_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/mouser_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/nabbit.conf
+++ b/sut/nabbit.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/nabbit_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/nabbit_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/nabbit_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/napple.conf
+++ b/sut/napple.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/napple/logs
 results_basedir: /data/testflinger-agent/tests/napple/results
 logging_level: INFO
 job_queues:
-- napple
 - anything
+- napple
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/napple_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/napple_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/napple_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/napple_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/octopot.conf
+++ b/sut/octopot.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/octopot_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/octopot_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/octopot_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/oogtar.conf
+++ b/sut/oogtar.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/oogtar/logs
 results_basedir: /data/testflinger-agent/tests/oogtar/results
 logging_level: INFO
 job_queues:
-- oogtar
 - anything
+- oogtar
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/oogtar_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/oogtar_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/oogtar_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/oogtar_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/penguru.conf
+++ b/sut/penguru.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/penguru/logs
 results_basedir: /data/testflinger-agent/tests/penguru/results
 logging_level: INFO
 job_queues:
-- anything
 - penguru
+- anything
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/penguru_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/penguru_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/penguru_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/penguru_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/pianta.conf
+++ b/sut/pianta.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/pianta/logs
 results_basedir: /data/testflinger-agent/tests/pianta/results
 logging_level: INFO
 job_queues:
-- pianta
 - anything
+- pianta
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/pianta_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/pianta_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/pianta_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/pianta_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/pikmin.conf
+++ b/sut/pikmin.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/pikmin_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/pikmin_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/pikmin_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/polari.conf
+++ b/sut/polari.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/polari/logs
 results_basedir: /data/testflinger-agent/tests/polari/results
 logging_level: INFO
 job_queues:
-- polari
 - anything
+- polari
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/polari_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/polari_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/polari_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/polari_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/prunes.conf
+++ b/sut/prunes.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/prunes_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/prunes_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/prunes_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/prunus.conf
+++ b/sut/prunus.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/prunus/logs
 results_basedir: /data/testflinger-agent/tests/prunus/results
 logging_level: INFO
 job_queues:
-- anything
 - prunus
+- anything
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/prunus_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/prunus_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/prunus_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/prunus_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/rozary.conf
+++ b/sut/rozary.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/rozary/logs
 results_basedir: /data/testflinger-agent/tests/rozary/results
 logging_level: INFO
 job_queues:
-- anything
 - rozary
+- anything
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/rozary_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/rozary_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/rozary_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/rozary_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/saiph.conf
+++ b/sut/saiph.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/saiph/logs
 results_basedir: /data/testflinger-agent/tests/saiph/results
 logging_level: INFO
 job_queues:
-- saiph
 - anything
+- saiph
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/saiph_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/saiph_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/saiph_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/saiph_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/salout.conf
+++ b/sut/salout.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/salout/logs
 results_basedir: /data/testflinger-agent/tests/salout/results
 logging_level: INFO
 job_queues:
-- salout
 - anything
+- salout
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/salout_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/salout_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/salout_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/salout_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/serviceberry.conf
+++ b/sut/serviceberry.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/serviceberry/logs
 results_basedir: /data/testflinger-agent/tests/serviceberry/results
 logging_level: INFO
 job_queues:
-- serviceberry
 - anything
+- serviceberry
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/serviceberry_snappy.yaml testflinger.json
@@ -19,7 +19,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/serviceberry_snappy.yaml testflinger.json
   || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/serviceberry_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/tabuu.conf
+++ b/sut/tabuu.conf
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/tabuu_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/tabuu_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/tabuu_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/tadrock.conf
+++ b/sut/tadrock.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/tadrock/logs
 results_basedir: /data/testflinger-agent/tests/tadrock/results
 logging_level: INFO
 job_queues:
-- tadrock
 - anything
+- tadrock
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/tadrock_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/tadrock_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/tadrock_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/tadrock_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/toadsworth.conf
+++ b/sut/toadsworth.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/toadsworth/logs
 results_basedir: /data/testflinger-agent/tests/toadsworth/results
 logging_level: INFO
 job_queues:
-- toadsworth
 - anything
+- toadsworth
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/toadsworth_snappy.yaml testflinger.json
@@ -19,7 +19,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/toadsworth_snappy.yaml testflinger.json ||
   /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/toadsworth_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/torchtusk.conf
+++ b/sut/torchtusk.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/torchtusk/logs
 results_basedir: /data/testflinger-agent/tests/torchtusk/results
 logging_level: INFO
 job_queues:
-- anything
 - torchtusk
+- anything
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/torchtusk_snappy.yaml testflinger.json
@@ -19,7 +19,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/torchtusk_snappy.yaml testflinger.json ||
   /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/torchtusk_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/whomp.conf
+++ b/sut/whomp.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/whomp/logs
 results_basedir: /data/testflinger-agent/tests/whomp/results
 logging_level: INFO
 job_queues:
-- whomp
 - anything
+- whomp
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/whomp_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/whomp_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/whomp_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/whomp_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/wildorange.conf
+++ b/sut/wildorange.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/wildorange/logs
 results_basedir: /data/testflinger-agent/tests/wildorange/results
 logging_level: INFO
 job_queues:
-- wildorange
 - anything
+- wildorange
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/wildorange_snappy.yaml testflinger.json
@@ -19,7 +19,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/wildorange_snappy.yaml testflinger.json ||
   /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/wildorange_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2

--- a/sut/wingo.conf
+++ b/sut/wingo.conf
@@ -2,17 +2,23 @@ agent_id: wingo
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
 output_timeout: 43200
-
 execution_basedir: /data/testflinger-agent/tests/wingo/run
 logging_basedir: /data/testflinger-agent/tests/wingo/logs
 results_basedir: /data/testflinger-agent/tests/wingo/results
 logging_level: INFO
-# logging_quiet: True
 job_queues:
-   - wingo
-
+- anything
+- wingo
 setup_command: echo Setup
-provision_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 provision -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json"
-test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 runtest -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json"
-reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json"
-cleanup_command: echo Cleanup
+provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  provision -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json
+test_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  runtest -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json
+reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  reserve -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json
+cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  cleanup -c /srv/testflinger-agent/sut/wingo_snappy.yaml testflinger.json || /bin/true
+provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  provision -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json
+allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  allocate -c /srv/testflinger-agent/sut/wingo_snappy.yaml testflinger.json

--- a/sut/wingo_snappy.yaml
+++ b/sut/wingo_snappy.yaml
@@ -1,8 +1,8 @@
-device_ip: 10.245.130.82
+device_ip: null
 node_id: dpmw3b
 node_name: wingo
 maas_user: testflinger_a
 agent_name: wingo
 env:
-    HEXR_DEVICE_SECURE_ID: FKFRkXHejhDH6MWXvZZz2p
-    DEVICE_IP: 10.245.130.82
+  HEXR_DEVICE_SECURE_ID: FKFRkXHejhDH6MWXvZZz2p
+  DEVICE_IP: null

--- a/sut/wooster.conf
+++ b/sut/wooster.conf
@@ -2,17 +2,23 @@ agent_id: wooster
 server_address: https://testflinger.canonical.com:443
 global_timeout: 172800
 output_timeout: 43200
-
 execution_basedir: /data/testflinger-agent/tests/wooster/run
 logging_basedir: /data/testflinger-agent/tests/wooster/logs
 results_basedir: /data/testflinger-agent/tests/wooster/results
 logging_level: INFO
-# logging_quiet: True
 job_queues:
-   - wooster
-
+- anything
+- wooster
 setup_command: echo Setup
-provision_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 provision -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json"
-test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 runtest -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json"
-reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json"
-cleanup_command: echo Cleanup
+provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  provision -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json
+test_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  runtest -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json
+reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  reserve -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json
+cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  cleanup -c /srv/testflinger-agent/sut/wooster_snappy.yaml testflinger.json || /bin/true
+provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  provision -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json
+allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
+  allocate -c /srv/testflinger-agent/sut/wooster_snappy.yaml testflinger.json

--- a/sut/wooster_snappy.yaml
+++ b/sut/wooster_snappy.yaml
@@ -4,5 +4,5 @@ node_name: wooster
 maas_user: testflinger_a
 agent_name: wooster
 env:
-    HEXR_DEVICE_SECURE_ID: MRzTSR8LvTVpZi7sC6S2AZ
-    DEVICE_IP: 10.245.130.83
+  HEXR_DEVICE_SECURE_ID: MRzTSR8LvTVpZi7sC6S2AZ
+  DEVICE_IP: 10.245.130.83

--- a/sut/ziptoad.conf
+++ b/sut/ziptoad.conf
@@ -7,8 +7,8 @@ logging_basedir: /data/testflinger-agent/tests/ziptoad/logs
 results_basedir: /data/testflinger-agent/tests/ziptoad/results
 logging_level: INFO
 job_queues:
-- ziptoad
 - anything
+- ziptoad
 setup_command: echo Setup
 provision_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/ziptoad_snappy.yaml testflinger.json
@@ -18,7 +18,6 @@ reserve_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent m
   reserve -c /data/snappy-device-agents/sut/ziptoad_snappy.yaml testflinger.json
 cleanup_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   cleanup -c /srv/testflinger-agent/sut/ziptoad_snappy.yaml testflinger.json || /bin/true
-output_timeouit: 43200
 provison_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2
   provision -c /data/snappy-device-agents/sut/ziptoad_snappy.yaml testflinger.json
 allocate_command: PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2


### PR DESCRIPTION
Updated the configs by fixing the typo in timeouit to timeout removed the bad key, and then re-ran the script to update.

configs were updated with the following command:
./maas_node_to_tf_configs.py cert "VLAN 2573" $HOME/canonical/testflinger-docker/sut/