### PR TITLE
Revert "corrected bad key for max_reserve_timeout SERVCERT-1197"

### DIFF
--- a/sut/aitken.conf
+++ b/sut/aitken.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/aitken_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/aitken_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/aitken_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/barbos.conf
+++ b/sut/barbos.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/barbos_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/barbos_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/barbos_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/beldam.conf
+++ b/sut/beldam.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/beldam_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/beldam_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/beldam_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/birdo.conf
+++ b/sut/birdo.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/birdo_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/birdo_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/birdo_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/blooper.conf
+++ b/sut/blooper.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  ma
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 reserve -c /data/snappy-device-agents/sut/blooper_snappy.yaml  testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 cleanup -c /data/snappy-device-agents/sut/blooper_snappy.yaml  testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 allocate -c /data/snappy-device-agents/sut/blooper_snappy.yaml  testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/blubi.conf
+++ b/sut/blubi.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/blubi_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/blubi_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/blubi_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/boddle.conf
+++ b/sut/boddle.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  ma
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 reserve -c /data/snappy-device-agents/sut/boddle_snappy.yaml  testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 cleanup -c /data/snappy-device-agents/sut/boddle_snappy.yaml  testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 allocate -c /data/snappy-device-agents/sut/boddle_snappy.yaml  testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/bomberto.conf
+++ b/sut/bomberto.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/bomberto_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/bomberto_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/bomberto_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/boshi.conf
+++ b/sut/boshi.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/boshi_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/boshi_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/boshi_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/buzzar.conf
+++ b/sut/buzzar.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/buzzar_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/buzzar_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/buzzar_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/cappy.conf
+++ b/sut/cappy.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/cappy_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/cappy_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/cappy_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/cloaker.conf
+++ b/sut/cloaker.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/cloaker_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/cloaker_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/cloaker_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/coinfish.conf
+++ b/sut/coinfish.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/coinfish_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/coinfish_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/coinfish_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/cractus.conf
+++ b/sut/cractus.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/cractus_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/cractus_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/cractus_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/danet.conf
+++ b/sut/danet.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/danet_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/danet_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/danet_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/donkeykong.conf
+++ b/sut/donkeykong.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/donkeykong_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/donkeykong_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/donkeykong_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/doubletusk.conf
+++ b/sut/doubletusk.conf
@@ -18,4 +18,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/doubletusk_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/doubletusk_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/doubletusk_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/drapion.conf
+++ b/sut/drapion.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/drapion_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/drapion_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/drapion_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/drilbur.conf
+++ b/sut/drilbur.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/drilbur_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/drilbur_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/drilbur_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/elden.conf
+++ b/sut/elden.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/elden_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/elden_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/elden_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/elroy.conf
+++ b/sut/elroy.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/elroy_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/elroy_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/elroy_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/fava.conf
+++ b/sut/fava.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/fava_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/fava_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/fava_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/ficet.conf
+++ b/sut/ficet.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/ficet_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/ficet_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/ficet_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/flavio.conf
+++ b/sut/flavio.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/flavio_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/flavio_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/flavio_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/fleep.conf
+++ b/sut/fleep.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/fleep_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/fleep_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/fleep_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/fleetroc.conf
+++ b/sut/fleetroc.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/fleetroc_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/fleetroc_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/fleetroc_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/garamond.conf
+++ b/sut/garamond.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/garamond_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/garamond_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/garamond_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/gloomer.conf
+++ b/sut/gloomer.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/gloomer_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/gloomer_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/gloomer_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/gravetusk.conf
+++ b/sut/gravetusk.conf
@@ -18,4 +18,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  ma
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 reserve -c /data/snappy-device-agents/sut/gravetusk_snappy.yaml  testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 cleanup -c /data/snappy-device-agents/sut/gravetusk_snappy.yaml  testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent  maas2 allocate -c /data/snappy-device-agents/sut/gravetusk_snappy.yaml  testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/gurley.conf
+++ b/sut/gurley.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/gurley_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/gurley_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/gurley_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/hardhat.conf
+++ b/sut/hardhat.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/hardhat_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/hardhat_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/hardhat_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/hildy.conf
+++ b/sut/hildy.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/hildy_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/hildy_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/hildy_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/hinopio.conf
+++ b/sut/hinopio.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/hinopio_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/hinopio_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/hinopio_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/hoggus.conf
+++ b/sut/hoggus.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/hoggus_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/hoggus_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/hoggus_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/hogplum.conf
+++ b/sut/hogplum.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/hogplum_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/hogplum_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/hogplum_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/hongo.conf
+++ b/sut/hongo.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/hongo_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/hongo_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/hongo_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/jamano.conf
+++ b/sut/jamano.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/jamano_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/jamano_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/jamano_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/jamiet.conf
+++ b/sut/jamiet.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/jamiet_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/jamiet_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/jamiet_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/jehan.conf
+++ b/sut/jehan.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/jehan_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/jehan_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/jehan_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/jellyplum.conf
+++ b/sut/jellyplum.conf
@@ -19,4 +19,4 @@ provision_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agen
 test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 runtest -c /data/snappy-device-agents/sut/jellyplum_snappy.yaml testflinger.json"
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/jellyplum_snappy.yaml testflinger.json"
 cleanup_command: echo Cleanup
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/joliet.conf
+++ b/sut/joliet.conf
@@ -20,4 +20,4 @@ reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent 
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/joliet_snappy.yaml testflinger.json || /bin/true"
 provision_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 provision -c /data/snappy-device-agents/sut/joliet_snappy.yaml testflinger.json"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/joliet_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/juppi.conf
+++ b/sut/juppi.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/juppi_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/juppi_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/juppi_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/keylime.conf
+++ b/sut/keylime.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/keylime_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/keylime_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/keylime_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/kongfu.conf
+++ b/sut/kongfu.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/kongfu_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/kongfu_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/kongfu_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/kroc.conf
+++ b/sut/kroc.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/kroc_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/kroc_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/kroc_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/krow.conf
+++ b/sut/krow.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/krow_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/krow_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/krow_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/krunch.conf
+++ b/sut/krunch.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/krunch_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/krunch_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/krunch_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/kuribo.conf
+++ b/sut/kuribo.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/kuribo_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/kuribo_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/kuribo_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/luma.conf
+++ b/sut/luma.conf
@@ -18,4 +18,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/luma_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/luma_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/luma_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/makrutlime.conf
+++ b/sut/makrutlime.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/makrutlime_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/makrutlime_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/makrutlime_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/manta.conf
+++ b/sut/manta.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/manta_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/manta_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/manta_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/mayapple.conf
+++ b/sut/mayapple.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/mayapple_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/mayapple_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/mayapple_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/mokura.conf
+++ b/sut/mokura.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/mokura_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/mokura_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/mokura_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/mouser.conf
+++ b/sut/mouser.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/mouser_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/mouser_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/mouser_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/multi-1.conf
+++ b/sut/multi-1.conf
@@ -16,4 +16,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent mul
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent multi allocate -c /data/snappy-device-agents/sut/multi-1_snappy.yaml testflinger.json"
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent multi reserve -c /data/snappy-device-agents/sut/multi-1_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent multi cleanup -c /data/snappy-device-agents/sut/multi-1_snappy.yaml testflinger.json || /bin/true"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/multi-2.conf
+++ b/sut/multi-2.conf
@@ -16,4 +16,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent mul
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent multi allocate -c /data/snappy-device-agents/sut/multi-2_snappy.yaml testflinger.json"
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent multi reserve -c /data/snappy-device-agents/sut/multi-2_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent multi cleanup -c /data/snappy-device-agents/sut/multi-2_snappy.yaml testflinger.json || /bin/true"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/nabbit.conf
+++ b/sut/nabbit.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/nabbit_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/nabbit_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/nabbit_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/napple.conf
+++ b/sut/napple.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/napple_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/napple_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/napple_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/octopot.conf
+++ b/sut/octopot.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/octopot_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/octopot_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/octopot_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/oogtar.conf
+++ b/sut/oogtar.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/oogtar_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/oogtar_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/oogtar_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/penguru.conf
+++ b/sut/penguru.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/penguru_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/penguru_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/penguru_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/pianta.conf
+++ b/sut/pianta.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/pianta_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/pianta_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/pianta_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/pikmin.conf
+++ b/sut/pikmin.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/pikmin_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/pikmin_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/pikmin_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/polari.conf
+++ b/sut/polari.conf
@@ -18,4 +18,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/polari_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/polari_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/polari_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/prunes.conf
+++ b/sut/prunes.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/prunes_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/prunes_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/prunes_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/prunus.conf
+++ b/sut/prunus.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/prunus_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/prunus_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/prunus_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/rozary.conf
+++ b/sut/rozary.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/rozary_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/rozary_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/rozary_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/saiph.conf
+++ b/sut/saiph.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/saiph_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/saiph_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/saiph_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/salout.conf
+++ b/sut/salout.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/salout_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/salout_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/salout_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/serviceberry.conf
+++ b/sut/serviceberry.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/serviceberry_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/serviceberry_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/serviceberry_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/smilax.conf
+++ b/sut/smilax.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/smilax_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/smilax_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/smilax_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/snide.conf
+++ b/sut/snide.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/snide_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/snide_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/snide_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/tabuu.conf
+++ b/sut/tabuu.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/tabuu_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/tabuu_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/tabuu_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/tadrock.conf
+++ b/sut/tadrock.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/tadrock_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/tadrock_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/tadrock_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/thudley.conf
+++ b/sut/thudley.conf
@@ -18,4 +18,4 @@ provision_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agen
 test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 runtest -c /data/snappy-device-agents/sut/thudley_snappy.yaml testflinger.json"
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/thudley_snappy.yaml testflinger.json"
 cleanup_command: echo Cleanup
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/toadsworth.conf
+++ b/sut/toadsworth.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/toadsworth_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/toadsworth_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/toadsworth_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/torchtusk.conf
+++ b/sut/torchtusk.conf
@@ -18,4 +18,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/torchtusk_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/torchtusk_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/torchtusk_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/whomp.conf
+++ b/sut/whomp.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/whomp_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/whomp_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/whomp_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/wildorange.conf
+++ b/sut/wildorange.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/wildorange_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/wildorange_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/wildorange_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/wingo.conf
+++ b/sut/wingo.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/wingo_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/wooster.conf
+++ b/sut/wooster.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/wooster_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009

--- a/sut/ziptoad.conf
+++ b/sut/ziptoad.conf
@@ -19,4 +19,4 @@ test_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maa
 reserve_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 reserve -c /data/snappy-device-agents/sut/ziptoad_snappy.yaml testflinger.json"
 cleanup_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 cleanup -c /data/snappy-device-agents/sut/ziptoad_snappy.yaml testflinger.json || /bin/true"
 allocate_command: "PYTHONIOENCODING=utf-8 PYTHONUNBUFFERED=1 snappy-device-agent maas2 allocate -c /data/snappy-device-agents/sut/ziptoad_snappy.yaml testflinger.json"
-max_reserve_timeout: 12096009
+max_reservation_timeout: 12096009


### PR DESCRIPTION
Reverts canonical/testflinger-docker#18

"voluptuous.error.MultipleInvalid: extra keys not allowed @ data['max_reserve_timeout']"

It appears that 'max_reserve_timeout' is invalid.