### PR TITLE
Remove torchtusk from micro-ceph queue

### DIFF
--- a/sut/torchtusk.conf
+++ b/sut/torchtusk.conf
@@ -13,7 +13,6 @@ job_queues:
 - dell
 - 202103-28757
 - charmed-ceph
-- micro-ceph
 logging_basedir: /data/testflinger-agent/tests/torchtusk/logs
 logging_level: INFO
 output_timeout: 43200


### PR DESCRIPTION
It contains only one disk.